### PR TITLE
Enable setting a color for the non-home keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ void setup() {
   Kaleidoscope.use(&LEDHomeKeys);
   
   // OPTIONALLY OVERRIDE THE PREDEFINED LED COLORS
+  // Set the non-home keys to a very dim gray using decimal values
+  LEDHomeKeys.thumb_color = CRGB(16,16,16);
   // Set the home thumb keys to a dim green using decimal values
   LEDHomeKeys.thumb_color = CRGB(0,128,0);
   // Set the home index finger keys to bright red (255,0,0) using hexadecimal
@@ -45,6 +47,11 @@ The plugin provides the `LEDHomeKeys` object, which has the following
 properties to set the LED colors used. In all cases, the values are
 `cRGB` values. They can be set either with decimal or hexadecimal values
  and can be set to `0,0,0` to turn off the corresponding LEDs.
+
+### `.non_home_key_color`
+Sets the color to use for all keys that aren't home keys. The default is a
+light gray `#303030` to make it easier to find the rest of the keys in the
+dark.
 
 ### `.index_finger_color`
 Sets the color to use for the two index finger home keys. The default is a

--- a/src/Kaleidoscope-LEDEffect-HomeKeys.cpp
+++ b/src/Kaleidoscope-LEDEffect-HomeKeys.cpp
@@ -17,6 +17,8 @@ namespace kaleidoscope {
        no performance penalty): cRGB ActiveModColorEffect::sticky_color = CRGB(0xff, 0, 0)
        */
 
+    cRGB LEDHomeKeys::non_home_key_color = CRGB(0x30, 0x30, 0x30);
+
 //    cRGB LEDHomeKeys::index_finger_color = (cRGB) {0x00, 0x00, 0x9f};
     cRGB LEDHomeKeys::index_finger_color =  CRGB(0x9f, 0x00, 0x00);
 
@@ -27,6 +29,8 @@ namespace kaleidoscope {
     cRGB LEDHomeKeys::thumb_color = CRGB(0x50, 0x00, 0x70);
 
     void LEDHomeKeys::onActivate(void) {
+        ::LEDControl.set_all_leds_to(non_home_key_color);
+
         // Row & Col map available at http://www.keyboard-layout-editor.com/#/gists/208ec9c7f9a08382c101b558f1d983b1
         ::LEDControl.setCrgbAt(2, 4, index_finger_color);           // Left Index (F)
         ::LEDControl.setCrgbAt(2, 3, non_index_fingers_color);      // Left Middle (D)

--- a/src/Kaleidoscope-LEDEffect-HomeKeys.h
+++ b/src/Kaleidoscope-LEDEffect-HomeKeys.h
@@ -8,6 +8,7 @@ namespace kaleidoscope {
     public:
         LEDHomeKeys(void) {}
 
+        static cRGB non_home_key_color;
         static cRGB index_finger_color;
         static cRGB non_index_fingers_color;
         static cRGB thumb_color;


### PR DESCRIPTION
I wanted to better be able to see the rest of the keys in low light.
I tried to pick a light white/gray that didn't overwhelm the home
keys but was still visible.

Thanks very much for this extension!  I made these changes for my own benefit, they might not fit with your vision, but I figured I'd let you make the call.